### PR TITLE
Fix minor spelling mistakes in BluetoothLE descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 											<a href="data/extensions/edu.mit.appinventor.BluetoothLE.aix">BluetoothLE.aix</a>
 										</td>
 										<td>
-											BluetootLE-Source.zip
+											BluetoothLE-Source.zip
 										</td>
 									</tr>
 
@@ -108,7 +108,7 @@
 						</div>
 						
 						<div class="alert alert-danger">
-						<i><strong>Note:</strong> The BleutoothLE component extension, was in part made possible by a grant given by the University Program Office at Intel Corporation.</i></div>
+						<i><strong>Note:</strong> The BluetoothLE component extension, was in part made possible by a grant given by the University Program Office at Intel Corporation.</i></div>
 			<h1>Unsupported:</h1>
 
 			<div class="table-responsive">


### PR DESCRIPTION
There are a few spelling errors in the description of the BluetoothLE extension. This commit corrects them.
