### PR TITLE
Update BluetoothLE on the extensions site

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 											<a href="data/extensions/edu.mit.appinventor.BluetoothLE.aix">BluetoothLE.aix</a>
 										</td>
 										<td>
-											BluetootLE-Source.zip
+											BluetoothLE-Source.zip
 										</td>
 									</tr>
 
@@ -108,7 +108,7 @@
 						</div>
 						
 						<div class="alert alert-danger">
-						<i><strong>Note:</strong> The BleutoothLE component extension, was in part made possible by a grant given by the University Program Office at Intel Corporation.</i></div>
+						<i><strong>Note:</strong> The BluetoothLE component extension, was in part made possible by a grant given by the University Program Office at Intel Corporation.</i></div>
 			<h1>Unsupported:</h1>
 
 			<div class="table-responsive">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
 		<meta name="description" content="MIT App Inventor Extensions">
-		<meta name="author" content="Jeffrey I. Schiller, William S. Byrne, Andrew F. McKinney">
+		<meta name="author" content="Jeffrey I. Schiller, William S. Byrne, Andrew F. McKinney, Evan W. Patton">
 		<link type="image/png" rel="icon" href="images/logo.png">
 
 		<title>MIT App Inventor Extensions</title>
@@ -50,7 +50,7 @@
 				<p>
 					This is the official resource for the MIT App Inventor Extensions, use them within your own projects. Explore, create and share new functionality through App Inventor Extensions.
 				</p>
-                <p><font color=red><b>The Supported binaries here have been compiled and tested for release NB149, all others are not supported yet. </b></font></p>
+                <p><font color=red><b>The Supported binaries here have been compiled and tested for release NB158, all others are not supported yet. </b></font></p>
 				<p>
 					<a class="btn btn-lg btn-success" href="http://ai2.appinventor.mit.edu" role="button">Try App Inventor Extensions &raquo;</a>
 				</p>
@@ -87,7 +87,7 @@
 										</td>
 										<td>
 											Adds as Bluetooth Low Energy functionality to your applications. See 
-			                                <a href="https://docs.google.com/document/d/1Y2Jk90BRskLKw3ex3yvftBmaEm7kyCcVCQy8yGAmtA4/pub">
+			                                <a href="http://iot.appinventor.mit.edu/#/bluetoothle/bluetoothleintro">
 												BluetoothLE Documentation and Resources
 											</a>for more information.
 										</td>
@@ -95,7 +95,7 @@
 											MIT App Inventor
 										</td>
 										<td>
-											<a href="data/extensions/edu.mit.appinventor.BluetoothLE.aix">BluetoothLE.aix</a>
+											<a href="http://iot.appinventor.mit.edu/assets/resources/edu.mit.appinventor.ble.aix">BluetoothLE.aix</a>
 										</td>
 										<td>
 											BluetoothLE-Source.zip


### PR DESCRIPTION
This PR updates the Bluetooth low energy extension description to point at the resources on the new MIT App Inventor + IoT website. Currently, people downloading the BLE extension via the extensions site will be getting the very old version without the permission fixes.